### PR TITLE
[IE] Use height instead of line-height

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -75,7 +75,7 @@ $fancy-field-breakpoints: (
   border-bottom: 1px solid $fancy-field-border-color;
   display: inline-block;
   font-weight: 100;
-  line-height: 2;
+  height: 2em;
   @include fancy-field-media-query(palm) {
     font-size: 1.125rem;
   }


### PR DESCRIPTION
[Unitless line-height](https://developer.mozilla.org/en/docs/Web/CSS/line-height) is not supported in IE
See [this post](http://joshnh.com/weblog/line-height-doesnt-work-as-expected-on-inputs/) for more info
