### PR TITLE
Using onInput on IE11 and onChange on all other browsers

### DIFF
--- a/src/FancyField.jsx
+++ b/src/FancyField.jsx
@@ -28,9 +28,14 @@ import classnames from 'classnames';
 import immutable, {fromJS} from 'immutable';
 
 const fromTypeahead = 'FROM_TYPEAHEAD';
+const isIE11 = !(window.ActiveXObject) && "ActiveXObject" in window;
 
 function isImmutable(obj) {
   return obj !== null && typeof obj === "object" && !!obj.toJSON;
+}
+
+function getInputOnChangeProps(handler) {
+  return isIE11 ? { onInput: handler } : { onChange: handler };
 }
 
 export default React.createClass({
@@ -394,6 +399,7 @@ export default React.createClass({
              aria-invalid={shouldShowError}
              ref={(el) => this.fancyFieldEl = el}
              placeholder={placeholder}
+             {...getInputOnChangeProps(this.handleChange)}
              onChange={this.handleChange}
              onBlur={this.handleBlur}
              onFocus={this.handleFocus}


### PR DESCRIPTION
On IE11 when typing to fast the use of onChange makes that some letters are not showing, this is a know issue in react 15:

https://github.com/facebook/react/issues/7027

The solution is using `onInput` instead of `onChange`, however `onInput` could make the input wont work correctly in other IE versions, so the actual solution was to check if the browser is IE11 then use `onInput` else use `onChange`