### PR TITLE
Remove timeout from blur to track interaction correctly

### DIFF
--- a/src/FancyField.js
+++ b/src/FancyField.js
@@ -157,13 +157,10 @@ export default class extends React.Component {
   };
 
   handleBlur = (e) => {
-    // need time for typeahead item to be clicked, before hiding the typeahead
-    setTimeout(() => {
-      this.setState({
-        isFocused: false,
-        arrowSelectedTypeaheadOpt: null
-      });
-    }, 100);
+    this.setState({
+      isFocused: false,
+      arrowSelectedTypeaheadOpt: null
+    });
     this.handleUserAction(e, 'blur');
   };
 


### PR DESCRIPTION
Tested typeahead and I was able to select, the issue with this timeout is that is calling didUpdate before on a previous component because isFocus is true still even when is not, so the user has to click twice when selecting a component. 